### PR TITLE
v1.1.0: Fix card registration, false positives, add manual scan

### DIFF
--- a/custom_components/custom_component_monitor/__init__.py
+++ b/custom_components/custom_component_monitor/__init__.py
@@ -6,9 +6,11 @@ from pathlib import Path
 import shutil
 import time
 
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.typing import ConfigType
 import homeassistant.helpers.config_validation as cv
 
@@ -20,6 +22,8 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 CARD_JS = "custom-component-monitor-card.js"
 CARD_BASE_PATH = f"/local/{DOMAIN}/{CARD_JS}"
+
+SERVICE_SCAN_NOW = "scan_now"
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
@@ -54,7 +58,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 
 async def _register_lovelace_resource(hass: HomeAssistant) -> None:
-    """Add/update the card JS in lovelace_resources with a cache-bust tag."""
+    """Add/update the card JS in lovelace_resources with a cache-bust tag.
+
+    Handles both storage-mode and YAML-mode lovelace gracefully.
+    Users with YAML-mode resources must add the card manually.
+    """
     from homeassistant.components.lovelace import DOMAIN as LL_DOMAIN
     from homeassistant.components.lovelace.resources import (
         ResourceStorageCollection,
@@ -65,11 +73,20 @@ async def _register_lovelace_resource(hass: HomeAssistant) -> None:
         return
 
     ll_data = hass.data[LL_DOMAIN]
-    resources: ResourceStorageCollection | None = getattr(
-        ll_data, "resources", None
-    )
+    resources = getattr(ll_data, "resources", None)
     if resources is None:
         _LOGGER.debug("Lovelace resources collection not available")
+        return
+
+    # Only storage-mode collections support async_create_item / async_update_item.
+    # YAML-mode uses ResourceYAMLCollection which is read-only.
+    if not isinstance(resources, ResourceStorageCollection):
+        _LOGGER.info(
+            "Lovelace resources are configured in YAML mode. "
+            "Please add the card resource manually: "
+            "url: %s, type: module",
+            CARD_BASE_PATH,
+        )
         return
 
     if not resources.loaded:
@@ -110,6 +127,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = {}
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register the scan_now service (once)
+    if not hass.services.has_service(DOMAIN, SERVICE_SCAN_NOW):
+
+        async def handle_scan_now(call: ServiceCall) -> None:
+            """Handle the scan_now service call."""
+            coordinator = hass.data[DOMAIN].get("coordinator")
+            if coordinator is not None:
+                _LOGGER.info("Manual scan triggered via service call")
+                await coordinator.async_request_refresh()
+            else:
+                _LOGGER.warning("No coordinator available for manual scan")
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SCAN_NOW,
+            handle_scan_now,
+            schema=vol.Schema({}),
+        )
+
     return True
 
 
@@ -118,5 +155,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        # Remove service if no more entries
+        if hass.services.has_service(DOMAIN, SERVICE_SCAN_NOW):
+            hass.services.async_remove(DOMAIN, SERVICE_SCAN_NOW)
+        hass.data[DOMAIN].pop("coordinator", None)
 
     return unload_ok

--- a/custom_components/custom_component_monitor/manifest.json
+++ b/custom_components/custom_component_monitor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/loryanstrant/HA-CustomComponentMonitor/issues",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/custom_components/custom_component_monitor/sensor.py
+++ b/custom_components/custom_component_monitor/sensor.py
@@ -126,9 +126,19 @@ class ComponentScanner:
             candidates = [repo_short]
             if repo.get("name"):
                 candidates.append(repo["name"])
-            # Strip common prefixes like "ha-"
-            if repo_short.startswith("ha-"):
-                candidates.append(repo_short[3:])
+            rm_name = rm.get("name", "")
+            if rm_name:
+                candidates.append(rm_name)
+            # Strip common repo name prefixes
+            for prefix in ("ha-", "homeassistant-", "home-assistant-", "lovelace-"):
+                if repo_short.lower().startswith(prefix):
+                    candidates.append(repo_short[len(prefix):])
+            # Also strip trailing "-theme" / "-themes" suffix
+            for cand in list(candidates):
+                low = cand.lower()
+                for suffix in ("-theme", "-themes"):
+                    if low.endswith(suffix):
+                        candidates.append(cand[:len(cand) - len(suffix)])
             # Try the YAML filename (without extension) from manifest
             rm_filename = rm.get("filename", "")
             if rm_filename:
@@ -141,13 +151,16 @@ class ComponentScanner:
                 candidate = themes_dir / name
                 if candidate.exists():
                     return candidate
-            # Last resort: scan themes dir for dirs containing repo_short
+            # Broader match: check if dir name appears in a candidate or vice versa
             if themes_dir.exists():
                 for child in themes_dir.iterdir():
                     if child.is_dir():
-                        low = child.name.lower()
+                        dir_low = child.name.lower()
                         for name in candidates:
-                            if name and name.lower() in low:
+                            if not name:
+                                continue
+                            name_low = name.lower()
+                            if name_low in dir_low or dir_low in name_low:
                                 return child
         elif category == "plugin":
             candidates = [repo_short]
@@ -394,6 +407,10 @@ class ComponentScanner:
 
         Returns lowercased card type names (without the ``custom:`` prefix).
         E.g. ``["weather-forecast-card"]``.
+
+        Uses multiple strategies to handle cases where the JS filename
+        doesn't match the registered custom element name (e.g. Firemote,
+        Mushroom).
         """
         rm = repo.get("repository_manifest", {}) or {}
         full_name = repo.get("full_name", "")
@@ -406,9 +423,12 @@ class ComponentScanner:
         if manifest_fn and manifest_fn.endswith(".js"):
             names.append(manifest_fn[:-3].lower())
 
-        # 2) Scan the community directory for .js files
+        # 2) Scan the community directory for .js files and extract
+        #    customElements.define calls from them
         candidates = [repo_short]
         if repo_short.startswith("ha-"):
+            candidates.append(repo_short[3:])
+        if repo_short.startswith("HA-"):
             candidates.append(repo_short[3:])
         community_dir = self.config_dir / "www" / "community"
         for cname in candidates:
@@ -418,6 +438,11 @@ class ComponentScanner:
                     stem = js_file.stem.lower()
                     if stem not in names and not stem.endswith(".gz"):
                         names.append(stem)
+                    # Extract actual registered custom element names from JS
+                    ce_names = self._extract_custom_elements(js_file)
+                    for ce in ce_names:
+                        if ce not in names:
+                            names.append(ce)
 
         # 3) Fall back to repo short name if nothing found
         if not names:
@@ -428,6 +453,37 @@ class ComponentScanner:
             names.append(stripped)
 
         return names
+
+    _CE_DEFINE_RE = re.compile(
+        r'customElements\.define\(\s*["\']([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)["\']',
+        re.IGNORECASE,
+    )
+
+    def _extract_custom_elements(self, js_path: Path) -> list[str]:
+        """Extract custom element names from customElements.define() calls.
+
+        Reads up to 1MB of the JS file and returns all unique element names
+        that look like card types (contain a hyphen, as required by the
+        custom elements spec). Filters out editor elements.
+        """
+        try:
+            # Read a bounded amount to avoid huge memory use on large bundles
+            raw = js_path.read_bytes()[:1_048_576].decode("utf-8", errors="ignore")
+        except OSError:
+            return []
+
+        found: list[str] = []
+        for match in self._CE_DEFINE_RE.finditer(raw):
+            name = match.group(1).lower()
+            # Must contain a hyphen (custom elements spec requirement)
+            if "-" not in name:
+                continue
+            # Skip editor elements — they aren't card types
+            if name.endswith("-editor"):
+                continue
+            if name not in found:
+                found.append(name)
+        return found
 
     async def _collect_used_card_types(self) -> set[str]:
         """Return the set of custom card type names found in lovelace dashboards.
@@ -542,6 +598,17 @@ class ComponentScanner:
                     if ct in used_types:
                         is_used = True
                         break
+                # Prefix-based matching for multi-card libraries (e.g. Mushroom)
+                # If a derived name like "mushroom" matches any used card type
+                # starting with "mushroom-", count it as used.
+                if not is_used:
+                    for ct in card_types:
+                        for ut in used_types:
+                            if ut.startswith(ct + "-"):
+                                is_used = True
+                                break
+                        if is_used:
+                            break
 
             entry = {
                 "name": name,
@@ -819,6 +886,10 @@ async def async_setup_entry(
         raise ConfigEntryNotReady(
             f"Failed to initialize coordinator: {exc}"
         ) from exc
+
+    # Store coordinator reference so the scan_now service can access it
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["coordinator"] = coordinator
 
     entities = [
         CustomComponentMonitorSensor(coordinator, desc)

--- a/custom_components/custom_component_monitor/services.yaml
+++ b/custom_components/custom_component_monitor/services.yaml
@@ -1,0 +1,3 @@
+scan_now:
+  name: "Custom Component Monitor: manual scan"
+  description: Trigger an immediate scan of all HACS-installed custom components.

--- a/custom_components/custom_component_monitor/strings.json
+++ b/custom_components/custom_component_monitor/strings.json
@@ -28,5 +28,11 @@
         "name": "Unused Frontend Resources"
       }
     }
+  },
+  "services": {
+    "scan_now": {
+      "name": "Custom Component Monitor: manual scan",
+      "description": "Trigger an immediate scan of all HACS-installed custom components."
+    }
   }
 }

--- a/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
+++ b/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
@@ -2,7 +2,7 @@
  * Custom Component Monitor Card
  * A Lovelace card that displays unused HACS components.
  */
-var CARD_VERSION = "1.0.0";
+var CARD_VERSION = "1.1.0";
 
 var ALL_SECTIONS = ["integrations", "themes", "frontend"];
 


### PR DESCRIPTION
## v1.1.0 — Bug Fixes + Manual Scan Service

### Fixes

**Card registration crash with YAML-mode lovelace (#35, #38)**
- `_register_lovelace_resource` now checks if the resources collection is a `ResourceStorageCollection` before calling `async_create_item`/`async_update_item`
- Users with YAML-mode lovelace resources get a clear log message explaining how to add the card resource manually instead of an unhandled `AttributeError` exception
- This was the root cause of "Custom element not found" for fresh installs

**Frontend card false positives (#36, #39)**
- Added `_extract_custom_elements()` method that scans JS files for `customElements.define()` calls to discover actual registered card type names
- Handles both single-quote (`'firemote-card'`) and double-quote define calls
- Filters out editor elements (`-editor` suffix)
- Added prefix-based matching for multi-card libraries like Mushroom — if derived stem is `mushroom`, any used card type `mushroom-xxx-card` counts as a match
- Also handles `HA-` prefix stripping for repos like `HA-Firemote`

### New Features

**Manual scan service action**
- New `custom_component_monitor.scan_now` service for triggering immediate rescans
- Registered via `services.yaml` so it appears in the HA Services UI with proper name/description
- Coordinator reference stored in `hass.data` for service access

### Re: Issue #37
- Point 2 (CCM not listed in card sections) is by-design: the card shows only **unused** items, while CCM shows in the installed/used counts. This is correct behavior.
- Point 1 (option to see installed components) has been filed as a separate feature request: #40

### Files Changed
- `__init__.py` — YAML-mode guard, scan_now service registration
- `sensor.py` — `_extract_custom_elements()`, prefix matching, coordinator storage
- `manifest.json` — version 1.1.0
- `services.yaml` — new service definition
- `strings.json` — service strings
- `www/custom-component-monitor-card.js` — version 1.1.0