### PR TITLE
v1.1.1: Fix lovelace- prefix stripping in card type derivation

### DIFF
--- a/custom_components/custom_component_monitor/manifest.json
+++ b/custom_components/custom_component_monitor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/loryanstrant/HA-CustomComponentMonitor/issues",
   "requirements": [],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/custom_components/custom_component_monitor/sensor.py
+++ b/custom_components/custom_component_monitor/sensor.py
@@ -444,7 +444,18 @@ class ComponentScanner:
                         if ce not in names:
                             names.append(ce)
 
-        # 3) Fall back to repo short name if nothing found
+        # 3) Add prefix-stripped variants for every name collected so far
+        #    (e.g. "lovelace-horizon-card" → "horizon-card")
+        stripped_extras: list[str] = []
+        for n in names:
+            for prefix in ("lovelace-", "ha-"):
+                if n.startswith(prefix):
+                    stripped = n[len(prefix):]
+                    if stripped and stripped not in names and stripped not in stripped_extras:
+                        stripped_extras.append(stripped)
+        names.extend(stripped_extras)
+
+        # 4) Fall back to repo short name if nothing found
         if not names:
             stripped = repo_short.lower()
             for prefix in ("lovelace-", "ha-"):

--- a/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
+++ b/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
@@ -2,7 +2,7 @@
  * Custom Component Monitor Card
  * A Lovelace card that displays unused HACS components.
  */
-var CARD_VERSION = "1.1.0";
+var CARD_VERSION = "1.1.1";
 
 var ALL_SECTIONS = ["integrations", "themes", "frontend"];
 


### PR DESCRIPTION
## v1.1.1 — Fix `lovelace-` prefix in card type derivation

### Problem

Cards whose HACS repo name or JS filename starts with `lovelace-` (e.g. `lovelace-horizon-card`) were being derived as `custom:lovelace-horizon-card` instead of `custom:horizon-card`. This caused them to show as unused even when actively placed on a dashboard.

The `lovelace-` prefix stripping existed in the fallback path (step 3 of `_derive_card_types`), but that path never fired because the manifest filename and JS stem already populated the names list in steps 1–2.

### Fix

Added a new step 3 that strips `lovelace-` and `ha-` prefixes from **all** derived card type names (not just the fallback), ensuring the stripped variant is always included in the matching set.

### Files Changed
- `sensor.py` — prefix-stripped variants added to `_derive_card_types`
- `manifest.json` — version 1.1.1
- `www/custom-component-monitor-card.js` — version 1.1.1