### PR TITLE
Bump versions

### DIFF
--- a/custom_components/custom_component_monitor/manifest.json
+++ b/custom_components/custom_component_monitor/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/loryanstrant/HA-CustomComponentMonitor/issues",
   "requirements": [],
-  "version": "1.1.2"
+  "version": "1.1.3"
 }

--- a/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
+++ b/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
@@ -2,7 +2,7 @@
  * Custom Component Monitor Card
  * A Lovelace card that displays unused HACS components.
  */
-var CARD_VERSION = "1.1.2";
+var CARD_VERSION = "1.1.3";
 
 var ALL_SECTIONS = ["integrations", "themes", "frontend"];
 


### PR DESCRIPTION
This pull request introduces a minor version update for the Custom Component Monitor integration, incrementing the version from 1.1.2 to 1.1.3. The update is reflected both in the integration's manifest and in the Lovelace card JavaScript file.

Version bump:

* Updated the `version` field in `manifest.json` to 1.1.3 to reflect the new release.
* Updated the `CARD_VERSION` variable in `custom-component-monitor-card.js` to 1.1.3 for consistency with the integration version.