### PR TITLE
Bump version

### DIFF
--- a/custom_components/custom_component_monitor/manifest.json
+++ b/custom_components/custom_component_monitor/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/loryanstrant/HA-CustomComponentMonitor/issues",
   "requirements": [],
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
+++ b/custom_components/custom_component_monitor/www/custom-component-monitor-card.js
@@ -2,7 +2,7 @@
  * Custom Component Monitor Card
  * A Lovelace card that displays unused HACS components.
  */
-var CARD_VERSION = "1.3.0";
+var CARD_VERSION = "1.4.0";
 
 var ALL_SECTIONS = ["integrations", "themes", "frontend"];
 

--- a/custom_components/custom_component_monitor/www/update-action-tracker-card.js
+++ b/custom_components/custom_component_monitor/www/update-action-tracker-card.js
@@ -5,7 +5,7 @@
  * v0.1.1
  */
 
-const CARD_VERSION = "1.3.0";
+const CARD_VERSION = "1.4.0";
 const UAT_DOMAIN = "custom_component_monitor";
 
 /* -- Helpers -------------------------------------------------- */


### PR DESCRIPTION
This pull request updates the version number of the Custom Component Monitor integration and its associated frontend cards from 1.3.0 to 1.4.0. No other functional or code changes are included.

- Version bump:
  * Updated the `version` field in `manifest.json` to 1.4.0
  * Updated the `CARD_VERSION` variable in `custom-component-monitor-card.js` to 1.4.0
  * Updated the `CARD_VERSION` variable in `update-action-tracker-card.js` to 1.4.0